### PR TITLE
Fix open redirect vulnerability in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Mahindra Personalisation App - Customize your comfort kit with bespoke embroidery"
+    />
+
+    <!-- Security Headers -->
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+    <meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload">
+
+    <!-- CSP hardened, no redirects in JS, allow nonce for inline script -->
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'nonce-secure123'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob:; connect-src 'self'; object-src 'none'; media-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self';">
+
+    <!-- Anti-Clickjack: keep page hidden if framed (no redirect) -->
+    <style id="antiClickjack">html { display: none !important; }</style>
+    <script nonce="secure123">
+      (function() {
+        'use strict';
+        try {
+          if (self === top) {
+            var antiClickjack = document.getElementById('antiClickjack');
+            if (antiClickjack && antiClickjack.parentNode) {
+              antiClickjack.parentNode.removeChild(antiClickjack);
+            }
+          } else {
+            // Intentionally do not redirect to avoid DOM open redirect
+            // Page stays hidden by the antiClickjack style when framed
+          }
+        } catch (e) {
+          var fallback = document.getElementById('antiClickjack');
+          if (fallback && fallback.parentNode) {
+            fallback.parentNode.removeChild(fallback);
+          }
+        }
+      })();
+    </script>
+
+    <!-- Fonts (from env variables) -->
+    <link href="%REACT_APP_FONTS_CINZEL%" rel="stylesheet" crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link href="%REACT_APP_FONTS_MAIN%" rel="stylesheet" crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link href="%REACT_APP_FONTS_EXTENDED%" rel="stylesheet" crossorigin="anonymous" referrerpolicy="no-referrer">
+
+    <!-- Fallback fonts for noscript -->
+    <noscript>
+      <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important; }
+      </style>
+    </noscript>
+
+    <title>Mahindra Personalisation App</title>
+  </head>
+  <body class="font-loading">
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+  </html>
+


### PR DESCRIPTION
Refactor anti-clickjack script and update CSP to resolve "Client DOM Open Redirect" security findings.

The previous anti-clickjack script used `location.replace` with potentially tainted `origin` and `pathname`, leading to open redirect vulnerabilities. The updated script removes this redirect logic, keeping the page hidden if framed. CSP is hardened with `frame-ancestors 'none'` and `script-src 'nonce-secure123'` to prevent framing and support the inline script securely.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a4c4fe6-aba1-48f9-9bad-ddeefcaf6a50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a4c4fe6-aba1-48f9-9bad-ddeefcaf6a50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

